### PR TITLE
Cleared config.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+*.ini
 
 # C extensions
 *.so

--- a/config.ini
+++ b/config.ini
@@ -2,6 +2,6 @@
 imageeditor = 
 codeeditor = 
 version = 0.0.3
-recentproject = C:/dev/test/test.py
+recentproject = 
 soundeditor = 
 


### PR DESCRIPTION
I believe that when a developer (who can use any OS) forks this repository he/she should get a clean environment. That is, there should not be hardcoded `C:/dev/test/test.py` in the config file.

This pull request fixes it and makes sure something like this is not likely to happen again.
