### PR TITLE
Prevent Splash Screen from crashing on "Create Project" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,3 @@ nosetests.xml
 .project
 .pydevproject
 build/
-
-config.ini


### PR DESCRIPTION
I wrapped the problematic function call in a try block and at least now it can continue to open the main window.

I'm not sure if the sge directory that is missing is necessary for building a project.  
