### PR TITLE
Fix case for Example.json filename

### DIFF
--- a/Stellar.py
+++ b/Stellar.py
@@ -73,7 +73,7 @@ class MainWindow(QtGui.QMainWindow):
         #self.fname = QtGui.QFileDialog.getOpenFileName(self,
         #        "Open Project File", QtCore.QDir.currentPath(),
         #        "Project Files (*.JSON)")
-        self.fname = os.path.join("Example","Example.JSON")
+        self.fname = os.path.join("Example","Example.json")
 
         if not self.fname:
             return


### PR DESCRIPTION
Fixes an issue with a filename on case-sensitive platforms/filesystems (ie. Linux, OS X, ...), that prevents the application from starting.
